### PR TITLE
fix: don't assume utf8 request contents

### DIFF
--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -130,7 +130,7 @@ class ResponsesMockServer(BaseTestServer):
         route, response = await self._find_response(request)
         # ensures the request content is loaded even if the handler didn't
         # need it. This makes it available in`aresponses.history`
-        await request.text()
+        await request.read()
         self._history.append(RoutingLog(request, route, response))
         return response
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ disable = W0612,W0621
 source=aresponses
 
 [pytest]
-addopts = --doctest-modules -s --tb=native --cov
+addopts = --doctest-modules -s --tb=native
 norecursedirs = build dist
 
 [flake8]


### PR DESCRIPTION
Reported by @ctalkington: Library users were seeing test failures since #54 due to the assumption that request contents would be utf8 compatible.

Fixes #64