### PR TITLE
Support asyncio_mode = strict

### DIFF
--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -5,7 +5,7 @@ import re
 from copy import copy
 from typing import List, NamedTuple
 
-import pytest
+import pytest_asyncio
 from aiohttp import web, ClientSession
 from aiohttp.client_reqrep import ClientRequest
 from aiohttp.connector import TCPConnector
@@ -324,7 +324,7 @@ class ResponsesMockServer(BaseTestServer):
         return self._history
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture()
 async def aresponses(event_loop) -> ResponsesMockServer:
     async with ResponsesMockServer(loop=event_loop) as server:
         yield server

--- a/aresponses/main.py
+++ b/aresponses/main.py
@@ -5,7 +5,13 @@ import re
 from copy import copy
 from typing import List, NamedTuple
 
-import pytest_asyncio
+try:
+    from pytest_asyncio import fixture as asyncio_fixture
+except ImportError:
+    # Backward compatability for pytest-asyncio<0.17
+    import pytest
+    asyncio_fixture = pytest.fixture
+
 from aiohttp import web, ClientSession
 from aiohttp.client_reqrep import ClientRequest
 from aiohttp.connector import TCPConnector
@@ -324,7 +330,7 @@ class ResponsesMockServer(BaseTestServer):
         return self._history
 
 
-@pytest_asyncio.fixture()
+@asyncio_fixture()
 async def aresponses(event_loop) -> ResponsesMockServer:
     async with ResponsesMockServer(loop=event_loop) as server:
         yield server

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ source=aresponses
 [pytest]
 addopts = --doctest-modules -s --tb=native
 norecursedirs = build dist
+asyncio_mode = strict
 
 [flake8]
 max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,4 @@ asyncio_mode = strict
 [flake8]
 max-line-length = 88
 extend-ignore = E203,E800,VNE001,VNE002
+pytest-mark-no-parentheses = True


### PR DESCRIPTION
Tests that use the `aresponses` fixture together with a recent version of `pytest-asyncio` (>= 0.17) and `asyncio_mode = strict` (see https://github.com/pytest-dev/pytest-asyncio#modes) are currently failing with: `Exception: Asynchronous fixtures must depend on the 'loop' fixture or be used in tests depending from it.`

Fix it by using `@pytest_asyncio.fixture()` instead of `@pytest.fixture()`.

Also make `flake8-pytest-style` happy again, see commit message.